### PR TITLE
[AMRCS-443] modify OdomCheckerStatus.msg.

### DIFF
--- a/msg/OdomCheckerStatus.msg
+++ b/msg/OdomCheckerStatus.msg
@@ -69,6 +69,8 @@ bool has_large_right_wheel_acc
 bool has_large_wheel_resistance
 bool has_wheel_stuck
 
+bool has_motor_driver_error
+
 # for filtering values
 sensor_msgs/Imu imu_raw
 sensor_msgs/Imu imu_filtered


### PR DESCRIPTION
Close AMRCS-443

- [x] Success in build.
- [x] /odom_checker_status topic has no issue in publishing: works fine.
```
imu_raw: 
  header: 
    seq: 7827
    stamp: 
      secs: 1728544706
      nsecs: 224360472
    frame_id: "base_link"
  orientation: 
    x: nan
    y: nan
    z: nan
    w: nan
  orientation_covariance: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
  angular_velocity: 
    x: 0.00035402633846518705
    y: 0.004411441821361766
    z: 0.003228749967820477
  angular_velocity_covariance: [0.0004446004520538685, -1.8707513143432099e-07, 0.0, -1.8707513143432099e-07, 0.00032713956794613164, 0.0, 0.0, 0.0, 0.00046986676]
  linear_acceleration: 
    x: -0.05587625649814464
    y: -0.044928463950387174
    z: 9.80643081665039
  linear_acceleration_covariance: [0.004579836593653058, 4.732054879844209e-07, 0.0, 4.732054879844209e-07, 0.0048769532363469445, 0.0, 0.0, 0.0, 0.00637623746]
imu_filtered: 
  header: 
    seq: 7827
    stamp: 
      secs: 1728544706
      nsecs: 224360472
    frame_id: "base_link"
  orientation: 
    x: nan
    y: nan
    z: nan
    w: nan
  orientation_covariance: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
  angular_velocity: 
    x: 0.00035402633846518705
    y: 0.004411441821361766
    z: -0.052999075443363436
  angular_velocity_covariance: [0.0004446004520538685, -1.8707513143432099e-07, 0.0, -1.8707513143432099e-07, 0.00032713956794613164, 0.0, 0.0, 0.0, 0.00046986676]
  linear_acceleration: 
    x: -0.07728440675573713
    y: -0.07414410693356037
    z: 9.80643081665039
  linear_acceleration_covariance: [0.004579836593653058, 4.732054879844209e-07, 0.0, 4.732054879844209e-07, 0.0048769532363469445, 0.0, 0.0, 0.0, 0.00637623746]
odom_raw: 
  linear: 
    x: -0.0005483981221914291
    y: 0.0
    z: 0.0
  angular: 
    x: 0.0
    y: 0.0
    z: -0.09574126452207565
odom_filtered: 
  linear: 
    x: -0.00041743193125989847
    y: 0.0
    z: 0.0
  angular: 
    x: 0.0
    y: 0.0
    z: -0.09932714536805445
left_velocity_raw: -0.008003544993698597
left_velocity_filtered: -0.006345860742650288
right_velocity_raw: 0.008202961646020412
right_velocity_filtered: 0.006558726408031296
---
```